### PR TITLE
🚨 Hotfix: Vercel deployment crash 수정

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@azure-rest/ai-translation-text": "^1.0.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0"


### PR DESCRIPTION
## 🚨 긴급 수정

Vercel 배포 환경에서 500 에러 발생 문제를 해결합니다.

### 문제
- 사용하지 않는 @azure-rest/ai-translation-text 패키지가 Vercel 환경에서 충돌 발생
- 실제로는 직접 HTTPS 요청을 사용하므로 SDK 불필요

### 해결
- package.json에서 @azure-rest/ai-translation-text 의존성 제거

### 테스트
- 로컬 환경 정상 작동 확인
- Vercel 배포 후 확인 필요

**긴급 배포 필요**